### PR TITLE
Replace the public L7 load balancer with a L4 load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,12 +358,12 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 80
-      nodePort: ${nginx_ingress_controller_http_nodeport}
+      nodePort: ${nginx_ingress_controller_http_nodeport} # default to 30080
     - name: https
       port: 443
       protocol: TCP
       targetPort: 443
-      nodePort: ${nginx_ingress_controller_https_nodeport}
+      nodePort: ${nginx_ingress_controller_https_nodeport} # default to 30443
   type: NodePort
 ```
 
@@ -392,11 +392,11 @@ metadata:
   namespace: ingress-nginx
 ```
 
-**NOTE** to use nginx ingress controller with the proxy protocol enabled on each worker will be installed nginx. The configuation of nginx will:
+**NOTE** to use nginx ingress controller with the proxy protocol enabled, an external nginx instance is used as proxy. Nginx will be installed on each worker node and the configuation of nginx will:
 
 * listen in proxy protocol mode
-* forward the traffic from port 80 to nginx_ingress_controller_http_nodeport on any server of the cluster
-* forward the traffic from port 443 to nginx_ingress_controller_https_nodeport on any server of the cluster
+* forward the traffic from port 80 to nginx_ingress_controller_http_nodeport (default to 30080) on any server of the cluster
+* forward the traffic from port 443 to nginx_ingress_controller_https_nodeport (default to 30443) on any server of the cluster
 
 ### Cert-manager
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,10 @@ metadata:
 * forward the traffic from port 80 to nginx_ingress_controller_http_nodeport (default to 30080) on any server of the cluster
 * forward the traffic from port 443 to nginx_ingress_controller_https_nodeport (default to 30443) on any server of the cluster
 
+This is the final result:
+
+Client -> Public L4 LB -> nginx proxy (with proxy protocol enabled) -> nginx ingress (with proxy protocol enabled) -> k3s service -> pod(s)
+
 ### Cert-manager
 
 [cert-manager](https://cert-manager.io/docs/) is used to issue certificates from a variety of supported source. To use cert-manager take a look at [this](deployments/nginx/nginx-ingress-cert-manager.yml) example. To use cert-manager and get the certificate you **need** set on your DNS configuration the public ip address of the load balancer.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,6 @@ Once you have created the terraform.tfvars file edit the main.tf file (always in
 | `unique_tag_key`  | `no`  | Unique tag name used for tagging all the deployed resources. Default: k3s-provisioner |
 | `unique_tag_value`  | `no`  | Unique value used with  unique_tag_key. Default: https://github.com/garutilorenzo/k3s-oci-cluster |
 | `PATH_TO_PUBLIC_KEY`     | `no`       | Path to your public ssh key (Default: "~/.ssh/id_rsa.pub) |
-| `PATH_TO_PRIVATE_KEY` | `no`        | Path to your private ssh key (Default: "~/.ssh/id_rsa) |
 
 #### Generate random token
 

--- a/README.md
+++ b/README.md
@@ -170,69 +170,6 @@ rerun this command to reinitialize your working directory. If you forget, other
 commands will detect it and remind you to do so if necessary.
 ```
 
-#### Generate sel signed SSL certificate for the public LB (L7)
-
-**NOTE** If you already own a valid certificate skip this step and set the correct values for the variables: PATH_TO_PUBLIC_LB_CERT and PATH_TO_PUBLIC_LB_KEY
-
-We need to generate the certificates (sel signed) for our public load balancer (Layer 7). To do this we need *openssl*, open a terminal and follow this step:
-
-Generate the key:
-
-```
-openssl genrsa 2048 > privatekey.pem
-Generating RSA private key, 2048 bit long modulus (2 primes)
-.......+++++
-...............+++++
-e is 65537 (0x010001)
-```
-
-Generate the a new certificate request:
-
-```
-openssl req -new -key privatekey.pem -out csr.pem
-You are about to be asked to enter information that will be incorporated
-into your certificate request.
-What you are about to enter is what is called a Distinguished Name or a DN.
-There are quite a few fields but you can leave some blank
-For some fields there will be a default value,
-If you enter '.', the field will be left blank.
------
-Country Name (2 letter code) [AU]:IT
-State or Province Name (full name) [Some-State]:Italy
-Locality Name (eg, city) []:Brescia
-Organization Name (eg, company) [Internet Widgits Pty Ltd]:GL Ltd
-Organizational Unit Name (eg, section) []:IT
-Common Name (e.g. server FQDN or YOUR name) []:testlb.domainexample.com
-Email Address []:email@you.com
-
-Please enter the following 'extra' attributes
-to be sent with your certificate request
-A challenge password []:
-An optional company name []:
-```
-
-Generate the public CRT:
-
-```
-openssl x509 -req -days 365 -in csr.pem -signkey privatekey.pem -out public.crt
-Signature ok
-subject=C = IT, ST = Italy, L = Brescia, O = GL Ltd, OU = IT, CN = testlb.domainexample.com, emailAddress = email@you.com
-Getting Private key
-```
-
-This is the final result:
-
-```
-ls
-
-csr.pem  privatekey.pem  public.crt
-```
-
-Now set the variables:
-
-* PATH_TO_PUBLIC_LB_CERT: ~/full_path/public.crt
-* PATH_TO_PUBLIC_LB_KEY: ~/full_path/privatekey.pem
-
 ### Oracle provider setup
 
 In the *example/* directory of this repo you need to create a terraform.tfvars file, the file will look like:
@@ -266,8 +203,6 @@ Once you have created the terraform.tfvars file edit the main.tf file (always in
 | `k3s_token` | `yes`        | The token of your K3s cluster. [How to](#generate-random-token) generate a random token |
 | `my_public_ip_cidr` | `yes`        |  your public ip in cidr format (Example: 195.102.xxx.xxx/32) |
 | `environment`  | `yes`  | Current work environment (Example: staging/dev/prod). This value is used for tag all the deployed resources |
-| `PATH_TO_PUBLIC_LB_CERT`  | `yes`  | Path to the public LB certificate. See [how to](#generate-sel-signed-ssl-certificate-for-the-public-lb-l7) generate the certificate |
-| `PATH_TO_PUBLIC_LB_KEY`  | `yes`  | Path to the public LB key. See [how to](#generate-sel-signed-ssl-certificate-for-the-public-lb-l7) generate the key |
 | `compute_shape`  | `no`  | Compute shape to use. Default VM.Standard.A1.Flex. **NOTE** Is mandatory to use this compute shape for provision 4 always free VMs |
 | `os_image_id`  | `no`  | Image id to use. Default image: Canonical-Ubuntu-20.04-aarch64-2022.01.18-0. See [how](#how-to-list-all-the-os-images) to list all available OS images |
 | `oci_core_vcn_dns_label`  | `no`  | VCN DNS label. Default: defaultvcn |
@@ -287,8 +222,14 @@ Once you have created the terraform.tfvars file edit the main.tf file (always in
 | `k3s_server_pool_size`  | `no`  | Number of k3s servers deployed. Default 2  |
 | `k3s_worker_pool_size`  | `no`  | Number of k3s workers deployed. Default 2  |
 | `install_nginx_ingress`  | `no`  | Boolean value, install kubernetes nginx ingress controller instead of Traefik. Default: true. For more information see [Nginx ingress controller](#nginx-ingress-controller) |
+nginx_ingress_controller_http_nodeport
+| `nginx_ingress_controller_http_nodeport`  | `30080`  | NodePort where nginx ingress will listen for http traffic  |
+| `nginx_ingress_controller_https_nodeport`  | `30443`  | NodePort where nginx ingress will listen for https traffic  |
 | `install_longhorn`  | `no`  | Boolean value, install longhorn "Cloud native distributed block storage for Kubernetes". Default: true  |
 | `longhorn_release`  | `no`  | Longhorn release. Default: v1.2.3  |
+| `install_certmanager`  | `no`  | Boolean value, install [cert manager](https://cert-manager.io/) "Cloud native certificate management". Default: true  |
+| `longhorn_release`  | `no`  | Cert manager release. Default: v1.8.2  |
+| `certmanager_email_address`  | `no`  | Email address used for signing https certificates. Defaul: changeme@example.com  |
 | `unique_tag_key`  | `no`  | Unique tag name used for tagging all the deployed resources. Default: k3s-provisioner |
 | `unique_tag_value`  | `no`  | Unique value used with  unique_tag_key. Default: https://github.com/garutilorenzo/k3s-oci-cluster |
 | `PATH_TO_PUBLIC_KEY`     | `no`       | Path to your public ssh key (Default: "~/.ssh/id_rsa.pub) |
@@ -398,7 +339,7 @@ This setup will automatically install [longhorn](https://longhorn.io/). Longhorn
 
 In this environment [Nginx ingress controller](https://kubernetes.github.io/ingress-nginx/) is used instead of the standard [Traefik](https://traefik.io/) ingress controller.
 
-The installation is the [bare metal](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal-clusters) installation, the ingress controller then is exposed via a LoadBalancer Service.
+The installation is the [bare metal](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal-clusters) installation, the ingress controller then is exposed via a NodePort Service.
 
 ```yaml
 ---
@@ -417,25 +358,26 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 80
+      nodePort: ${nginx_ingress_controller_http_nodeport}
     - name: https
       port: 443
       protocol: TCP
-      targetPort: 80
-  type: LoadBalancer
+      targetPort: 443
+      nodePort: ${nginx_ingress_controller_https_nodeport}
+  type: NodePort
 ```
 
-To properly configure all the Forwarded HTTP Headers (L7 Headers) this parameters are added to che ConfigMap:
+To get the real ip address of the clients using a public L4 load balancer we need to use the proxy protocol feature of nginx ingress controller:
 
 ```yaml
 ---
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  use-forwarded-headers: "true"
-  compute-full-forwarded-for: "true"
   enable-real-ip: "true"
-  forwarded-for-header: "X-Forwarded-For"
   proxy-real-ip-cidr: "0.0.0.0/0"
+  proxy-body-size: "20m"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -449,6 +391,16 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ```
+
+**NOTE** to use nginx ingress controller with the proxy protocol enabled on each worker will be installed nginx. The configuation of nginx will:
+
+* listen in proxy protocol mode
+* forward the traffic from port 80 to nginx_ingress_controller_http_nodeport on any server of the cluster
+* forward the traffic from port 443 to nginx_ingress_controller_https_nodeport on any server of the cluster
+
+### Cert-manager
+
+[cert-manager](https://cert-manager.io/docs/) is used to issue certificates from a variety of supported source. To use cert-manager take a look at [this](deployments/nginx/nginx-ingress-cert-manager.yml) example. To use cert-manager and get the certificate you **need** set on your DNS configuration the public ip address of the load balancer.
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Client -> Public L4 LB -> nginx proxy (with proxy protocol enabled) -> nginx ing
 
 ### Cert-manager
 
-[cert-manager](https://cert-manager.io/docs/) is used to issue certificates from a variety of supported source. To use cert-manager take a look at [this](deployments/nginx/nginx-ingress-cert-manager.yml) example. To use cert-manager and get the certificate you **need** set on your DNS configuration the public ip address of the load balancer.
+[cert-manager](https://cert-manager.io/docs/) is used to issue certificates from a variety of supported source. To use cert-manager take a look at [nginx-ingress-cert-manager.yml](deployments/nginx/nginx-ingress-cert-manager.yml) and [nginx-configmap-cert-manager.yml](deployments/nginx/nginx-configmap-cert-manager.yml) example. To use cert-manager and get the certificate you **need** set on your DNS configuration the public ip address of the load balancer.
 
 ## Deploy
 

--- a/data.tf
+++ b/data.tf
@@ -5,14 +5,20 @@ data "template_cloudinit_config" "k3s_server_tpl" {
   part {
     content_type = "text/x-shellscript"
     content = templatefile("${path.module}/files/k3s-install-server.sh", {
-      k3s_token             = var.k3s_token, is_k3s_server = true,
-      install_nginx_ingress = var.install_nginx_ingress,
-      compartment_ocid      = var.compartment_ocid,
-      availability_domain   = var.availability_domain,
-      k3s_url               = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
-      k3s_tls_san           = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
-      install_longhorn      = var.install_longhorn,
-      longhorn_release      = var.longhorn_release
+      k3s_token                               = var.k3s_token,
+      is_k3s_server                           = true,
+      install_nginx_ingress                   = var.install_nginx_ingress,
+      install_certmanager                     = var.install_certmanager,
+      certmanager_release                     = var.certmanager_release,
+      certmanager_email_address               = var.certmanager_email_address,
+      compartment_ocid                        = var.compartment_ocid,
+      availability_domain                     = var.availability_domain,
+      k3s_url                                 = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
+      k3s_tls_san                             = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
+      install_longhorn                        = var.install_longhorn,
+      longhorn_release                        = var.longhorn_release,
+      nginx_ingress_controller_http_nodeport  = var.nginx_ingress_controller_http_nodeport,
+      nginx_ingress_controller_https_nodeport = var.nginx_ingress_controller_https_nodeport,
     })
   }
 }
@@ -24,9 +30,13 @@ data "template_cloudinit_config" "k3s_worker_tpl" {
   part {
     content_type = "text/x-shellscript"
     content = templatefile("${path.module}/files/k3s-install-agent.sh", {
-      k3s_token     = var.k3s_token,
-      is_k3s_server = false,
-      k3s_url       = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
+      k3s_token                               = var.k3s_token,
+      is_k3s_server                           = false,
+      k3s_url                                 = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
+      http_lb_port                            = var.http_lb_port,
+      https_lb_port                           = var.https_lb_port,
+      nginx_ingress_controller_http_nodeport  = var.nginx_ingress_controller_http_nodeport,
+      nginx_ingress_controller_https_nodeport = var.nginx_ingress_controller_https_nodeport,
     })
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -4,7 +4,16 @@ data "template_cloudinit_config" "k3s_server_tpl" {
 
   part {
     content_type = "text/x-shellscript"
-    content      = templatefile("${path.module}/files/k3s-install-server.sh", { k3s_token = var.k3s_token, is_k3s_server = true, install_nginx_ingress = var.install_nginx_ingress, compartment_ocid = var.compartment_ocid, availability_domain = var.availability_domain, k3s_url = local.k3s_int_lb_dns_name, k3s_tls_san = local.k3s_int_lb_dns_name, install_longhorn = var.install_longhorn, longhorn_release = var.longhorn_release })
+    content = templatefile("${path.module}/files/k3s-install-server.sh", {
+      k3s_token             = var.k3s_token, is_k3s_server = true,
+      install_nginx_ingress = var.install_nginx_ingress,
+      compartment_ocid      = var.compartment_ocid,
+      availability_domain   = var.availability_domain,
+      k3s_url               = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
+      k3s_tls_san           = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
+      install_longhorn      = var.install_longhorn,
+      longhorn_release      = var.longhorn_release
+    })
   }
 }
 
@@ -14,7 +23,11 @@ data "template_cloudinit_config" "k3s_worker_tpl" {
 
   part {
     content_type = "text/x-shellscript"
-    content      = templatefile("${path.module}/files/k3s-install-agent.sh", { k3s_token = var.k3s_token, is_k3s_server = false, k3s_url = local.k3s_int_lb_dns_name })
+    content = templatefile("${path.module}/files/k3s-install-agent.sh", {
+      k3s_token     = var.k3s_token,
+      is_k3s_server = false,
+      k3s_url       = oci_load_balancer_load_balancer.k3s_load_balancer.ip_addresses[0],
+    })
   }
 }
 

--- a/deployments/nginx/nginx-configmap-cert-manager.yml
+++ b/deployments/nginx/nginx-configmap-cert-manager.yml
@@ -1,0 +1,423 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+data:
+  nginx.conf: |
+    user nginx;
+    worker_processes  1;
+    
+    error_log  /dev/stderr warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      sendfile        on;
+    
+      tcp_nopush on;
+      tcp_nodelay on;
+      
+      keepalive_timeout 65;
+
+      types_hash_max_size 2048;
+      client_max_body_size 20M;
+      
+      ##
+      # SSL Settings
+      ##
+
+      ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+      ssl_prefer_server_ciphers on;
+      
+      set_real_ip_from 0.0.0.0/0;
+
+      log_format main '$remote_addr - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent"';
+
+      access_log  /dev/stdout  main;
+
+      ##
+      # Gzip Settings
+      ##
+
+      gzip on;
+      gzip_disable "msie6";
+
+      gzip_vary on;
+      gzip_proxied any;
+      gzip_comp_level 6;
+      gzip_buffers 16 8k;
+      gzip_http_version 1.1;
+      gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+      include /etc/nginx/conf.d/*.conf;
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wordpress-conf-tpl
+data:
+  wordpress.conf.template: |
+    server {
+      listen       80 default_server;
+      listen  [::]:80 default_server;
+
+      server_name example.com example1.com;
+      root /var/www/html;
+      index index.html index.php;
+      
+      client_max_body_size 20M;
+
+      # Security
+      include /etc/nginx/custom.conf.d/nginx-custom.conf;
+      include /etc/nginx/custom.conf.d/wp-hardening.conf;
+
+      # Prevent Clickjacking
+      add_header X-Frame-Options "SAMEORIGIN";
+      add_header X-Content-Type-Options "nosniff";
+
+      charset utf-8;
+
+      # Set the custom error pages
+      error_page 404 /index.php;
+      error_page 403 /index.php;
+
+      # Logs
+      error_log /dev/stderr;
+      access_log /dev/stdout main;
+     
+      location ~* /xmlrpc.php$ {
+        fastcgi_pass ${KUBE_SVC_NAME}:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+        allow ${SECURE_SUBNET};
+        allow 127.0.0.1; 
+        deny all;
+      }
+
+      # Remove direct access to the following folders & files
+      location ~* ^/(?:\.|conf|data/(?:files|personal|logs|plugins|tmp|cache)|plugins/editor.zoho/agent/files) {
+          deny all;
+      }
+
+      location ~* /data/public/.*.(ser|htaccess)$ {
+          deny all;
+      }
+
+      # Stops the annoying error messages in the logs
+      location ~* ^/(favicon.ico|robots.txt) {
+          log_not_found off;
+      }
+
+      location = /favicon.ico {
+          expires 1y;
+          log_not_found off;
+          access_log off;
+      }
+
+      location ~ ^/(wp-admin|wp-login.php) {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass ${KUBE_SVC_NAME}:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+
+        allow ${SECURE_SUBNET};
+        allow 127.0.0.1; 
+        deny all;
+      }
+
+      # Enables PHP
+      location ~ \.php$ {
+          fastcgi_split_path_info ^(.+\.php)(/.+)$;
+          fastcgi_pass ${KUBE_SVC_NAME}:9000;
+          fastcgi_index index.php;
+          include fastcgi_params;
+          fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+          fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+      }
+
+      # Enables Caching
+      location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
+          expires 7d;
+          add_header Pragma public;
+          add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+      }
+
+      # The rewrite magic
+      location / {
+          try_files $uri $uri/ /index.php?$args;
+      }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-custom-conf
+data:
+  nginx-custom.conf: |
+    # Directives to send expires headers and turn off 404 error logging.
+    location ~* ^.+\.(curl|heic|swf|tiff|rss|atom|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf)$ {
+        log_not_found off;
+        expires max;
+    }
+
+    # Web fonts send expires headers
+    location ~* \.(?:eot|otf|ttf|woff|woff2)$ {
+        expires max;
+        add_header Cache-Control "public";
+    }
+
+    # SVGs & MP4 WEBM send expires headers - this rule is set specific to ns site
+    location ~* \.(?:svg|svgz|mp4|webm)$ {
+        expires max;
+        add_header Cache-Control "public";
+    }
+
+    # Media: images, icons, video, audio send expires headers.
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|aac|m4a|mp3|ogg|ogv|webp)$ {
+        expires 1M;
+        add_header Cache-Control "public";
+    }
+
+    # Cache css & js files
+    location ~* \.(?:css(\.map)?|js(\.map)?)$ {
+        add_header "Access-Control-Allow-Origin" "*";
+        log_not_found off;
+        expires 30d;
+    }
+
+    # CSS and Javascript send expires headers.
+    location ~* \.(?:css|js)$ {
+        expires 1y;
+        add_header Cache-Control "public";
+    }
+
+    # HTML send expires headers.
+    location ~* \.(html)$ {
+        expires 7d;
+        add_header Cache-Control "public";
+    }
+
+    # Security settings for better privacy
+    # Deny hidden files
+    # Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).
+    location ~ /\. {
+        deny all;
+    }
+
+    # Return 403 forbidden for readme.(txt|html) or license.(txt|html) or example.(txt|html) or other common git repository files
+    location ~*  "/(^$|readme|license|example|README|LEGALNOTICE|INSTALLATION|CHANGELOG)\.(txt|html|md)" {
+        deny all;
+    }
+
+    # Deny backup extensions & log files and return 403 forbidden
+    location ~* "\.(old|orig|original|php#|php~|php_bak|save|swo|aspx?|tpl|sh|bash|bak?|cfg|cgi|dll|exe|git|hg|ini|jsp|log|mdb|out|sql|svn|swp|tar|rdf)$" {
+        deny all;
+    }
+
+    # common nginx configuration to block sql injection and other attacks
+    location ~* "(eval\()" {
+        deny all;
+    }
+    location ~* "(127\.0\.0\.1)" {
+        deny all;
+    }
+    location ~* "([a-z0-9]{2000})" {
+        deny all;
+    }
+    location ~* "(javascript\:)(.*)(\;)" {
+        deny all;
+    }
+
+    location ~* "(base64_encode)(.*)(\()" {
+        deny all;
+    }
+    location ~* "(GLOBALS|REQUEST)(=|\[|%)" {
+        deny all;
+    }
+    location ~* "(<|%3C).*script.*(>|%3)" {
+        deny all;
+    }
+    location ~ "(\\|\.\.\.|\.\./|~|`|<|>|\|)" {
+        deny all;
+    }
+    location ~* "(boot\.ini|etc/passwd|self/environ)" {
+        deny all;
+    }
+    location ~* "(thumbs?(_editor|open)?|tim(thumb)?)\.php" {
+        deny all;
+    }
+    location ~* "(\'|\")(.*)(drop|insert|md5|select|union)" {
+        deny all;
+    }
+    location ~* "(https?|ftp|php):/" {
+        deny all;
+    }
+    location ~* "(=\\\'|=\\%27|/\\\'/?)\." {
+        deny all;
+    }
+    location ~ "(\{0\}|\(/\(|\.\.\.|\+\+\+|\\\"\\\")" {
+        deny all;
+    }
+    location ~ "(~|`|<|>|:|;|%|\\|\s|\{|\}|\[|\]|\|)" {
+        deny all;
+    }
+    location ~* "/(=|\$&|_mm|(wp-)?config\.|cgi-|etc/passwd|muieblack)" {
+        deny all;
+    }
+
+    location ~* "(&pws=0|_vti_|\(null\)|\{\$itemURL\}|echo(.*)kae|etc/passwd|eval\(|self/environ)" {
+        deny all;
+    }
+    location ~* "/(^$|mobiquo|phpinfo|shell|sqlpatch|thumb|thumb_editor|thumbopen|timthumb|webshell|config|settings|configuration)\.php" {
+        deny all;
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wp-hardening
+data:
+  wp-hardening.conf: |
+    # Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).
+    location ~ /\. {
+        deny all;
+    }
+
+    # Deny access to any files with a .php extension in the uploads directory
+    location ~* /uploads/.*\.php$ {
+        deny all;
+    }
+
+    # Deny access to any files with a .php extension in the uploads directory for multisite
+    location ~* /files/.*\.php$ {
+        deny all;
+    }
+
+    # Since version 2.5.7, Akismet introduced a new .htaccess file to block direct access to php files
+    # Ref: http://wordpress.org/extend/plugins/akismet/changelog/
+    location ~* /akismet/.*\.php$ {
+        allow 127.0.0.1;
+        deny all;
+    }
+
+    # Restrict direct access to cached content
+    location /wp-content/cache/ {
+        deny all;
+    }
+
+    # hide any backup or SQL dump files
+    location ~ ^.+\.(sql|bak|php~|php#|php.save|php.swp|php.swo)$ {
+        deny all;
+    }
+
+    #Deny access to wp-content folders for suspicious files
+    location ~* ^/(wp-content)/(.*?)\.(zip|gz|tar|bzip2|7z)\$ {
+      deny all;
+    }
+
+    location ~ ^/wp-content/uploads/sucuri {
+      deny all;
+    }
+
+    location ~ ^/wp-content/updraft {
+      deny all;
+    }
+
+    #Disable execution of scripts other than PHP from your document root
+    location ~* .(pl|cgi|py|sh|lua|asp)$ {
+      return 444;
+    }
+
+    #Disable access to your configuration files and other files that you don’t want to users are able to see
+    location ~* /(wp-config.php|readme.html|license.txt|nginx.conf) {
+      deny all;
+    }
+
+    # Disable wp-config.txt
+    location = /wp-config.txt {
+        deny all;
+    }
+
+    # nginx block wpscann on plugins folder
+    location ~* ^/wp-content/plugins/.+\.(txt|log|md)$ {
+      deny all;
+      error_page 403 =404 / ;
+    }
+
+    # Deny access to any files with a .php extension in the uploads directory
+    # Works in sub-directory installs and also in multisite network
+    # Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)
+    location ~* /(?:uploads|files)/.*\.php$ {
+      deny all;
+    }
+
+    # Stop scann for the follow files on plugins folder
+    location ~* ^/wp-content/plugins/.+\.(txt|log|md)$ {
+          deny all;
+          error_page 403 =404 / ;
+    }
+
+    # Stop scann for the follow files on themes folder
+    location ~* ^/wp-content/themes/.+\.(txt|log|md)$ {
+          deny all;
+          error_page 403 =404 / ;
+    }
+
+    #This module will allow us to pattern match certain key files and inject random text in the files that
+    # is non-destructive / non-invasive and will most importantly alter the md5sum calculated on such files. All transparent to WPScan.
+    location ~* ^/(license.txt|wp-includes/(.*)/.+\.(js|css)|wp-admin/(.*)/.+\.(js|css))$ {
+        sub_filter_types text/css text/javascript text/plain;
+        sub_filter_once on;
+        sub_filter ';' '; /* $msec */ ';
+    }
+
+    #Direct PHP File Access
+    #If somehow, a hacker successfully sneaks in a PHP file onto your site,
+    #they’ll be able to run this file by loading file which effectively becomes a backdoor to infiltrate your site.
+    #We should disable direct access to any PHP files by adding the following rules:
+    location ~* /(?:uploads|files|wp-content|wp-includes|akismet)/.*.php$ {
+        deny all;
+    }
+
+    #Dotfiles
+    #Similar to PHP file, a dotfile like .htaccess, .user.ini, and .git may contain sensitive information.
+    #To be on the safer side, it’s better to disable direct access to these files.
+    location ~ /\.(svn|git)/* {
+        deny all;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    location ~ /\.user.ini {
+        deny all;
+    }
+
+    #WordFence
+    location ~ \.user\.ini$ {
+        deny all;
+    }
+
+
+    # WordPress: deny wp-content, wp-includes php files
+    location ~* ^/(?:wp-content|wp-includes)/.*\.php$ {
+        deny all;
+    }
+
+    # WordPress: deny wp-content/uploads nasty stuff
+    location ~* ^/wp-content/uploads/.*\.(?:s?html?|php|js|swf)$ {
+        deny all;
+    }

--- a/deployments/nginx/nginx-ingress-cert-manager.yml
+++ b/deployments/nginx/nginx-ingress-cert-manager.yml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-wp-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-staging" # or "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - example.com
+    - example1.com
+    secretName: example-tls
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx-svc
+                port:
+                  number: 80
+    - host: example1.com
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: nginx-svc
+                port:
+                  number: 80

--- a/example/main.tf
+++ b/example/main.tf
@@ -23,16 +23,15 @@ variable "region" {
 }
 
 module "k3s_cluster" {
-  region                 = var.region
-  availability_domain    = "<change_me>"
-  compartment_ocid       = var.compartment_ocid
-  PATH_TO_PUBLIC_LB_CERT = "<change_me>"
-  PATH_TO_PUBLIC_LB_KEY  = "<change_me>"
-  my_public_ip_cidr      = "<change_me>"
-  cluster_name           = "<change_me>"
-  environment            = "staging"
-  k3s_token              = "<change_me>"
-  source                 = "../"
+  region                    = var.region
+  availability_domain       = "<change_me>"
+  compartment_ocid          = var.compartment_ocid
+  my_public_ip_cidr         = "<change_me>"
+  cluster_name              = "<change_me>"
+  environment               = "staging"
+  k3s_token                 = "<change_me>"
+  certmanager_email_address = "<change_me>"
+  source                    = "../"
 }
 
 output "k3s_servers_ips" {

--- a/files/k3s-install-agent.sh
+++ b/files/k3s-install-agent.sh
@@ -24,7 +24,8 @@ systemctl disable netfilter-persistent.service
 apt-get update
 apt-get install -y software-properties-common jq
 DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y  python3 python3-pip
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y python3 python3-pip nginx
+systemctl enable nginx
 pip install oci-cli
 
 local_ip=$(curl -s -H "Authorization: Bearer Oracle" -L http://169.254.169.254/opc/v2/vnics/ | jq -r '.[0].privateIp')
@@ -36,3 +37,113 @@ until (curl -sfL https://get.k3s.io | K3S_TOKEN=${k3s_token} K3S_URL=https://${k
     echo 'k3s did not install correctly'
     sleep 2
 done
+
+cat << 'EOF' > /root/find_ips.sh
+export OCI_CLI_AUTH=instance_principal
+private_ips=()
+
+# Fetch the OCID of all the running instances in OCI and store to an array
+instance_ocids=$(oci search resource structured-search --query-text "QUERY instance resources where lifeCycleState='RUNNING'"  --query 'data.items[*].identifier' --raw-output | jq -r '.[]' ) 
+
+# Iterate through the array to fetch details of each instance one by one
+for val in ${instance_ocids[@]} ; do
+
+   echo $val
+
+   # Get name of the instance
+   instance_name=$(oci compute instance get --instance-id $val --raw-output --query 'data."display-name"')
+   echo $instance_name
+
+
+   # Get Public Ip of the instance
+   public_ip=$(oci compute instance list-vnics --instance-id $val --raw-output --query 'data[0]."public-ip"')
+   echo $public_ip
+
+   private_ip=$(oci compute instance list-vnics --instance-id $val --raw-output --query 'data[0]."private-ip"')
+   echo $private_ip
+   private_ips+=($private_ip)
+done
+
+for i in "${private_ips[@]}"
+do
+   echo "$i" >> /tmp/private_ips
+done
+EOF
+
+cat << 'EOF' > /root/nginx.tpl
+load_module /usr/lib/nginx/modules/ngx_stream_module.so;
+
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 768;
+    # multi_accept on;
+}
+
+stream {
+    upstream k3s-http {
+        {% for private_ip in private_ips -%}
+        server {{ private_ip }}:30080 max_fails=3 fail_timeout=10s;
+        {% endfor -%}
+    }
+    upstream k3s-https {
+        {% for private_ip in private_ips -%}
+        server {{ private_ip }}:30443 max_fails=3 fail_timeout=10s;
+        {% endfor -%}
+    }
+
+    log_format basic '$remote_addr [$time_local] '
+                 '$protocol $status $bytes_sent $bytes_received '
+                 '$session_time "$upstream_addr" '
+                 '"$upstream_bytes_sent" "$upstream_bytes_received" "$upstream_connect_time"';
+
+    access_log /var/log/nginx/k3s_access.log basic;
+    error_log  /var/log/nginx/k3s_error.log;
+
+    proxy_protocol on;
+
+    server {
+        listen 443;
+        proxy_pass k3s-https;
+        proxy_next_upstream on;
+    }
+
+    server {
+        listen 80;
+        proxy_pass k3s-http;
+        proxy_next_upstream on;
+    }
+}
+EOF
+
+cat << 'EOF' > /root/render_nginx_config.py
+from jinja2 import Template
+import os
+
+RAW_IP = open('/tmp/private_ips', 'r').readlines()
+IPS = [i.replace('\n','') for i in RAW_IP]
+
+nginx_config_template_path = '/root/nginx.tpl'
+nginx_config_path = '/etc/nginx/nginx.conf-test'
+
+with open(nginx_config_template_path, 'r') as handle:
+    nginx_config_template = handle.read()
+
+new_nginx_config = Template(nginx_config_template).render(
+    private_ips = IPS
+)
+
+with open(nginx_config_path, 'w') as handle:
+    handle.write(new_nginx_config)
+EOF
+
+chmod +x /root/find_ips.sh
+./root/find_ips.sh
+
+python3 /root/render_nginx_config.py
+
+nginx -t
+
+systemctl restart nginx

--- a/files/k3s-install-agent.sh
+++ b/files/k3s-install-agent.sh
@@ -46,7 +46,7 @@ private_ips=()
 instance_ocids=$(oci search resource structured-search --query-text "QUERY instance resources where lifeCycleState='RUNNING'"  --query 'data.items[*].identifier' --raw-output | jq -r '.[]' ) 
 
 # Iterate through the array to fetch details of each instance one by one
-for val in ${instance_ocids[@]} ; do
+for val in $${instance_ocids[@]} ; do
 
    echo $val
 
@@ -64,7 +64,7 @@ for val in ${instance_ocids[@]} ; do
    private_ips+=($private_ip)
 done
 
-for i in "${private_ips[@]}"
+for i in "$${private_ips[@]}"
 do
    echo "$i" >> /tmp/private_ips
 done
@@ -126,7 +126,7 @@ RAW_IP = open('/tmp/private_ips', 'r').readlines()
 IPS = [i.replace('\n','') for i in RAW_IP]
 
 nginx_config_template_path = '/root/nginx.tpl'
-nginx_config_path = '/etc/nginx/nginx.conf-test'
+nginx_config_path = '/etc/nginx/nginx.conf'
 
 with open(nginx_config_template_path, 'r') as handle:
     nginx_config_template = handle.read()

--- a/files/k3s-install-agent.sh
+++ b/files/k3s-install-agent.sh
@@ -85,12 +85,12 @@ events {
 stream {
     upstream k3s-http {
         {% for private_ip in private_ips -%}
-        server {{ private_ip }}:30080 max_fails=3 fail_timeout=10s;
+        server {{ private_ip }}:${nginx_ingress_controller_http_nodeport} max_fails=3 fail_timeout=10s;
         {% endfor -%}
     }
     upstream k3s-https {
         {% for private_ip in private_ips -%}
-        server {{ private_ip }}:30443 max_fails=3 fail_timeout=10s;
+        server {{ private_ip }}:${nginx_ingress_controller_https_nodeport} max_fails=3 fail_timeout=10s;
         {% endfor -%}
     }
 
@@ -105,13 +105,13 @@ stream {
     proxy_protocol on;
 
     server {
-        listen 443;
+        listen ${https_lb_port};
         proxy_pass k3s-https;
         proxy_next_upstream on;
     }
 
     server {
-        listen 80;
+        listen ${http_lb_port};
         proxy_pass k3s-http;
         proxy_next_upstream on;
     }

--- a/files/k3s-install-server.sh
+++ b/files/k3s-install-server.sh
@@ -74,7 +74,7 @@ fi
 %{ if install_nginx_ingress }
 if [[ "$first_last" == "first" ]]; then
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/baremetal/deploy.yaml
-cat << 'EOF' > /root/all-resources.yaml
+cat << 'EOF' > /root/nginx-ingress-resources.yaml
 ---
 apiVersion: v1
 kind: Service
@@ -119,7 +119,7 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 EOF
-    kubectl apply -f /root/all-resources.yaml
+    kubectl apply -f /root/nginx-ingress-resources.yaml
 fi
 %{ endif }
 

--- a/k3s-workers.tf
+++ b/k3s-workers.tf
@@ -1,7 +1,7 @@
 resource "oci_core_instance_pool" "k3s_workers" {
 
   depends_on = [
-    oci_network_load_balancer_network_load_balancer.k3s_load_balancer,
+    oci_load_balancer_load_balancer.k3s_load_balancer,
   ]
 
   lifecycle {

--- a/k3slb.tf
+++ b/k3slb.tf
@@ -43,7 +43,7 @@ resource "oci_network_load_balancer_backend" "k3s_http_backend" {
   count                    = var.k3s_server_pool_size
   backend_set_name         = oci_network_load_balancer_backend_set.k3s_http_backend_set.name
   network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
-  name                     = format("%s-%s", "https", data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].display_name)
+  name                     = format("%s:%s", data.oci_core_instance_pool_instances.k3s_servers_instances.instances[count.index].id, var.http_lb_port)
   port                     = var.http_lb_port
   target_id                = data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].id
 }
@@ -77,7 +77,7 @@ resource "oci_network_load_balancer_backend" "k3s_https_backend" {
   count                    = var.k3s_server_pool_size
   backend_set_name         = oci_network_load_balancer_backend_set.k3s_https_backend_set.name
   network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
-  name                     = data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].display_name
+  name                     = format("%s:%s", data.oci_core_instance_pool_instances.k3s_servers_instances.instances[count.index].id, var.https_lb_port)
   port                     = var.https_lb_port
   target_id                = data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].id
 }

--- a/k3slb.tf
+++ b/k3slb.tf
@@ -1,9 +1,10 @@
-resource "oci_network_load_balancer_network_load_balancer" "k3s_load_balancer" {
-  compartment_id = var.compartment_ocid
-  display_name   = var.k3s_load_balancer_name
-  subnet_id      = oci_core_subnet.oci_core_subnet11.id
+resource "oci_network_load_balancer_network_load_balancer" "k3s_public_lb" {
+  compartment_id             = var.compartment_ocid
+  display_name               = var.public_load_balancer_name
+  subnet_id                  = oci_core_subnet.oci_core_subnet11.id
+  network_security_group_ids = [oci_core_network_security_group.public_lb_nsg.id]
 
-  is_private                     = true
+  is_private                     = false
   is_preserve_source_destination = false
 
   freeform_tags = {
@@ -13,35 +14,70 @@ resource "oci_network_load_balancer_network_load_balancer" "k3s_load_balancer" {
   }
 }
 
-resource "oci_network_load_balancer_listener" "k3s_kube_api_listener" {
-  default_backend_set_name = oci_network_load_balancer_backend_set.k3s_kube_api_backend_set.name
-  name                     = "k3s kube api listener"
-  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_load_balancer.id
-  port                     = var.kube_api_port
+# HTTP
+resource "oci_network_load_balancer_listener" "k3s_http_listener" {
+  default_backend_set_name = oci_network_load_balancer_backend_set.k3s_http_backend_set.name
+  name                     = "k3s_http_listener"
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
+  port                     = var.http_lb_port
   protocol                 = "TCP"
 }
 
-resource "oci_network_load_balancer_backend_set" "k3s_kube_api_backend_set" {
+resource "oci_network_load_balancer_backend_set" "k3s_http_backend_set" {
   health_checker {
     protocol = "TCP"
-    port     = var.kube_api_port
+    port     = var.http_lb_port
   }
 
-  name                     = "k3s_kube_api_backend"
-  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_load_balancer.id
+  name                     = "k3s_http_backend"
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
   policy                   = "FIVE_TUPLE"
   is_preserve_source       = true
 }
 
-resource "oci_network_load_balancer_backend" "k3s_kube_api_backend" {
+resource "oci_network_load_balancer_backend" "k3s_http_backend" {
   depends_on = [
-    oci_core_instance_pool.k3s_servers,
+    oci_core_instance_pool.k3s_workers,
   ]
 
   count                    = var.k3s_server_pool_size
-  backend_set_name         = oci_network_load_balancer_backend_set.k3s_kube_api_backend_set.name
-  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_load_balancer.id
-  name                     = format("%s:%s", data.oci_core_instance_pool_instances.k3s_servers_instances.instances[count.index].id, var.kube_api_port)
-  port                     = var.kube_api_port
-  target_id                = data.oci_core_instance_pool_instances.k3s_servers_instances.instances[count.index].id
+  backend_set_name         = oci_network_load_balancer_backend_set.k3s_http_backend_set.name
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
+  name                     = format("%s-%s", "https", data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].display_name)
+  port                     = var.http_lb_port
+  target_id                = data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].id
+}
+
+# HTTPS
+resource "oci_network_load_balancer_listener" "k3s_https_listener" {
+  default_backend_set_name = oci_network_load_balancer_backend_set.k3s_https_backend_set.name
+  name                     = "k3s_https_listener"
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
+  port                     = var.https_lb_port
+  protocol                 = "TCP"
+}
+
+resource "oci_network_load_balancer_backend_set" "k3s_https_backend_set" {
+  health_checker {
+    protocol = "TCP"
+    port     = var.https_lb_port
+  }
+
+  name                     = "k3s_https_backend"
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
+  policy                   = "FIVE_TUPLE"
+  is_preserve_source       = true
+}
+
+resource "oci_network_load_balancer_backend" "k3s_https_backend" {
+  depends_on = [
+    oci_core_instance_pool.k3s_workers,
+  ]
+
+  count                    = var.k3s_server_pool_size
+  backend_set_name         = oci_network_load_balancer_backend_set.k3s_https_backend_set.name
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
+  name                     = data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].display_name
+  port                     = var.https_lb_port
+  target_id                = data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,3 @@
-locals {
-  k3s_int_lb_dns_name = format("%s.%s.%s.oraclevcn.com", replace(var.k3s_load_balancer_name, " ", "-"), var.oci_core_subnet_dns_label11, var.oci_core_vcn_dns_label)
-}
+# locals {
+#   k3s_int_lb_dns_name = format("%s.%s.%s.oraclevcn.com", replace(var.k3s_load_balancer_name, " ", "-"), var.oci_core_subnet_dns_label11, var.oci_core_vcn_dns_label)
+# }

--- a/nsg.tf
+++ b/nsg.tf
@@ -27,7 +27,6 @@ resource "oci_core_network_security_group_security_rule" "allow_http_from_all" {
       min = var.http_lb_port
     }
   }
-
 }
 
 resource "oci_core_network_security_group_security_rule" "allow_https_from_all" {
@@ -47,5 +46,54 @@ resource "oci_core_network_security_group_security_rule" "allow_https_from_all" 
       min = var.https_lb_port
     }
   }
+}
 
+resource "oci_core_network_security_group" "lb_to_instances" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.default_oci_core_vcn.id
+  display_name   = "Public LB to Compute Instances NSG"
+
+  freeform_tags = {
+    "provisioner"           = "terraform"
+    "environment"           = "${var.environment}"
+    "${var.unique_tag_key}" = "${var.unique_tag_value}"
+  }
+}
+
+resource "oci_core_network_security_group_security_rule" "nsg_to_instances_http" {
+  network_security_group_id = oci_core_network_security_group.lb_to_instances.id
+  direction                 = "INGRESS"
+  protocol                  = 6 # tcp
+
+  description = "Allow HTTP from all"
+
+  source      = oci_core_network_security_group.public_lb_nsg.id
+  source_type = "NETWORK_SECURITY_GROUP"
+  stateless   = false
+
+  tcp_options {
+    destination_port_range {
+      max = var.http_lb_port
+      min = var.http_lb_port
+    }
+  }
+}
+
+resource "oci_core_network_security_group_security_rule" "nsg_to_instances_https" {
+  network_security_group_id = oci_core_network_security_group.lb_to_instances.id
+  direction                 = "INGRESS"
+  protocol                  = 6 # tcp
+
+  description = "Allow HTTPS from all"
+
+  source      = oci_core_network_security_group.public_lb_nsg.id
+  source_type = "NETWORK_SECURITY_GROUP"
+  stateless   = false
+
+  tcp_options {
+    destination_port_range {
+      max = var.https_lb_port
+      min = var.https_lb_port
+    }
+  }
 }

--- a/oci/provider.tf
+++ b/oci/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 4.64.0"
+    }
+  }
+}
+
+provider "oci" {}

--- a/output.tf
+++ b/output.tf
@@ -13,5 +13,5 @@ output "k3s_workers_ips" {
 }
 
 output "public_lb_ip" {
-  value = oci_load_balancer_load_balancer.k3s_public_lb.ip_addresses
+  value = oci_network_load_balancer_network_load_balancer.k3s_public_lb.ip_addresses
 }

--- a/template.tf
+++ b/template.tf
@@ -41,6 +41,7 @@ resource "oci_core_instance_configuration" "k3s_server_template" {
       create_vnic_details {
         assign_public_ip = true
         subnet_id        = oci_core_subnet.default_oci_core_subnet10.id
+        nsg_ids          = [oci_core_network_security_group.lb_to_instances.id]
       }
 
       display_name = "Ubuntu k3s server template"

--- a/template.tf
+++ b/template.tf
@@ -41,7 +41,6 @@ resource "oci_core_instance_configuration" "k3s_server_template" {
       create_vnic_details {
         assign_public_ip = true
         subnet_id        = oci_core_subnet.default_oci_core_subnet10.id
-        nsg_ids          = [oci_core_network_security_group.lb_to_instances.id]
       }
 
       display_name = "Ubuntu k3s server template"
@@ -107,6 +106,7 @@ resource "oci_core_instance_configuration" "k3s_worker_template" {
       create_vnic_details {
         assign_public_ip = true
         subnet_id        = oci_core_subnet.default_oci_core_subnet10.id
+        nsg_ids          = [oci_core_network_security_group.lb_to_instances.id]
       }
 
       display_name = "Ubuntu k3s worker template"

--- a/vars.tf
+++ b/vars.tf
@@ -33,12 +33,6 @@ variable "PATH_TO_PUBLIC_KEY" {
   description = "Path to your public key"
 }
 
-variable "PATH_TO_PRIVATE_KEY" {
-  type        = string
-  default     = "~/.ssh/id_rsa"
-  description = "Path to your private key"
-}
-
 variable "os_image_id" {
   type    = string
   default = "ocid1.image.oc1.eu-zurich-1.aaaaaaaag2uyozo7266bmg26j5ixvi42jhaujso2pddpsigtib6vfnqy5f6q" # Canonical-Ubuntu-20.04-aarch64-2022.01.18-0

--- a/vars.tf
+++ b/vars.tf
@@ -115,6 +115,17 @@ variable "https_lb_port" {
   default = 443
 }
 
+variable "nginx_ingress_controller_http_nodeport" {
+  type    = number
+  default = 30080
+}
+
+variable "nginx_ingress_controller_https_nodeport" {
+  type    = number
+  default = 30443
+}
+
+
 variable "PATH_TO_PUBLIC_LB_CERT" {
   type        = string
   description = "Path to the public LB https certificate"
@@ -153,6 +164,21 @@ variable "my_public_ip_cidr" {
 variable "install_nginx_ingress" {
   type    = bool
   default = true
+}
+
+variable "install_certmanager" {
+  type    = bool
+  default = true
+}
+
+variable "certmanager_release" {
+  type    = string
+  default = "v1.8.2"
+}
+
+variable "certmanager_email_address" {
+  type    = string
+  default = "changeme@example.com"
 }
 
 variable "install_longhorn" {

--- a/vars.tf
+++ b/vars.tf
@@ -125,17 +125,6 @@ variable "nginx_ingress_controller_https_nodeport" {
   default = 30443
 }
 
-
-variable "PATH_TO_PUBLIC_LB_CERT" {
-  type        = string
-  description = "Path to the public LB https certificate"
-}
-
-variable "PATH_TO_PUBLIC_LB_KEY" {
-  type        = string
-  description = "Path to the public LB key"
-}
-
 variable "k3s_server_pool_size" {
   type    = number
   default = 2


### PR DESCRIPTION
Replace the public L7 load balancer with a L4 load balancer:

* the generation of the https certificates is not needed anymore
* cert-manager is used to issue certificates
* nginx ingess uses the proxy protocol to preserve the client ip address