### PR TITLE
Dynamic groups can only be created in the root compartment

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -25,6 +25,7 @@ variable "region" {
 module "k3s_cluster" {
   region                    = var.region
   availability_domain       = "<change_me>"
+  tenancy_ocid              = var.tenancy_ocid
   compartment_ocid          = var.compartment_ocid
   my_public_ip_cidr         = "<change_me>"
   cluster_name              = "<change_me>"

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "oci_identity_dynamic_group" "compute_dynamic_group" {
-  compartment_id = var.compartment_ocid
+  compartment_id = var.tenancy_ocid
   description    = "Dynamic group which contains all instance in this compartment"
   matching_rule  = "All {instance.compartment.id = '${var.compartment_ocid}'}"
   name           = var.oci_identity_dynamic_group_name
@@ -13,11 +13,11 @@ resource "oci_identity_dynamic_group" "compute_dynamic_group" {
 
 resource "oci_identity_policy" "compute_dynamic_group_policy" {
   compartment_id = var.compartment_ocid
-  description    = "Policy to allow dynamic group ${oci_identity_dynamic_group.compute_dynamic_group.name} to read OCI api"
+  description    = "Policy to allow dynamic group ${oci_identity_dynamic_group.compute_dynamic_group.name} to read instance-family and compute-management-family in the compartment"
   name           = var.oci_identity_policy_name
   statements = [
-    "allow dynamic-group ${oci_identity_dynamic_group.compute_dynamic_group.name} to read instance-family in tenancy",
-    "allow dynamic-group ${oci_identity_dynamic_group.compute_dynamic_group.name} to read compute-management-family in tenancy"
+    "allow dynamic-group ${oci_identity_dynamic_group.compute_dynamic_group.name} to read instance-family in compartment id ${var.compartment_ocid}",
+    "allow dynamic-group ${oci_identity_dynamic_group.compute_dynamic_group.name} to read compute-management-family in compartment id ${var.compartment_ocid}"
   ]
 
   freeform_tags = {

--- a/vars.tf
+++ b/vars.tf
@@ -6,6 +6,10 @@ variable "availability_domain" {
   type = string
 }
 
+variable "tenancy_ocid" {
+
+}
+
 variable "compartment_ocid" {
   type = string
 }


### PR DESCRIPTION
Using the tenancy OCID as the compartment OCID is the way to ensure that Terraform creates the dynamic group successfully.

This PR also tightens up the policy by only allowing the dynamic group to read `instance-family` and `compute-management-family` in the compartment created by Terraform and not the entire tenancy.

Signed-off-by: Avi Miller <avi.miller@oracle.com>