### PR TITLE
Update deployments and docs. os_image_id now is a required variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ To use this repo you will need:
 
 Once you get the account, follow the *Before you begin* and *1. Prepare* step in [this](https://docs.oracle.com/en-us/iaas/developer-tutorials/tutorials/tf-provider/01-summary.htm) document.
 
+### Terraform OCI user creation (Optional)
+
+Is always recommended to create a separate user an group to use with Terraform. This user must have less privileges possible (Zero trust policy). This is an example policy that allow *terraform-group* to manage all the resources needed by this module:
+
+```
+Allow group terraform-group to manage virtual-network-family  in compartment id <compartment_ocid>
+Allow group terraform-group to manage instance-family  in compartment id <compartment_ocid>
+Allow group terraform-group to manage compute-management-family  in compartment id <compartment_ocid>
+Allow group terraform-group to manage volume-family  in compartment id <compartment_ocid>
+Allow group terraform-group to manage load-balancers  in compartment id <compartment_ocid>
+Allow group terraform-group to manage network-load-balancers  in compartment id <compartment_ocid>
+Allow group terraform-group to manage dynamic-groups in compartment id <compartment_ocid>
+Allow group terraform-group to manage policies in compartment id <compartment_ocid>
+Allow group terraform-group to read network-load-balancers  in compartment id <compartment_ocid>
+```
+
+The user and the group have to be manually created before using this module.
+To create the user go to Identity & Security -> Users, then create the group in Identity & Security -> Groups and associate the newly created user to the group. The last step is to create the policy in Identity & Security -> Policies.
+
 #### Example RSA key generation
 
 To use terraform with the Oracle Cloud infrastructure you need to generate an RSA key. Generate the rsa key with:
@@ -203,8 +222,8 @@ Once you have created the terraform.tfvars file edit the main.tf file (always in
 | `k3s_token` | `yes`        | The token of your K3s cluster. [How to](#generate-random-token) generate a random token |
 | `my_public_ip_cidr` | `yes`        |  your public ip in cidr format (Example: 195.102.xxx.xxx/32) |
 | `environment`  | `yes`  | Current work environment (Example: staging/dev/prod). This value is used for tag all the deployed resources |
+| `os_image_id`  | `yes`  | Image id to use. See [how](#how-to-list-all-the-os-images) to list all available OS images |
 | `compute_shape`  | `no`  | Compute shape to use. Default VM.Standard.A1.Flex. **NOTE** Is mandatory to use this compute shape for provision 4 always free VMs |
-| `os_image_id`  | `no`  | Image id to use. Default image: Canonical-Ubuntu-20.04-aarch64-2022.01.18-0. See [how](#how-to-list-all-the-os-images) to list all available OS images |
 | `oci_core_vcn_dns_label`  | `no`  | VCN DNS label. Default: defaultvcn |
 | `oci_core_subnet_dns_label10`  | `no`  | First subnet DNS label. Default: defaultsubnet10 |
 | `oci_core_subnet_dns_label11`  | `no`  | Second subnet DNS label. Default: defaultsubnet11 |

--- a/data.tf
+++ b/data.tf
@@ -8,6 +8,7 @@ data "template_cloudinit_config" "k3s_server_tpl" {
       k3s_token                               = var.k3s_token,
       is_k3s_server                           = true,
       install_nginx_ingress                   = var.install_nginx_ingress,
+      nginx_ingress_release                   = var.nginx_ingress_release,
       install_certmanager                     = var.install_certmanager,
       certmanager_release                     = var.certmanager_release,
       certmanager_email_address               = var.certmanager_email_address,

--- a/files/k3s-install-server.sh
+++ b/files/k3s-install-server.sh
@@ -174,7 +174,7 @@ fi
 
 %{ if install_nginx_ingress }
 if [[ "$first_last" == "first" ]]; then
-  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/baremetal/deploy.yaml
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${nginx_ingress_release}/deploy/static/provider/baremetal/deploy.yaml
   NGINX_RESOURCES_FILE=/root/nginx-ingress-resources.yaml
   render_nginx_config
   kubectl apply -f $NGINX_RESOURCES_FILE

--- a/vars.tf
+++ b/vars.tf
@@ -26,6 +26,10 @@ variable "cluster_name" {
   type = string
 }
 
+variable "os_image_id" {
+  type    = string
+}
+
 variable "fault_domains" {
   type    = list(any)
   default = ["FAULT-DOMAIN-1", "FAULT-DOMAIN-2", "FAULT-DOMAIN-3"]
@@ -35,11 +39,6 @@ variable "PATH_TO_PUBLIC_KEY" {
   type        = string
   default     = "~/.ssh/id_rsa.pub"
   description = "Path to your public key"
-}
-
-variable "os_image_id" {
-  type    = string
-  default = "ocid1.image.oc1.eu-zurich-1.aaaaaaaailwa7imzkgvd5oc7nrfzq4b7cpk7xbkiuz2kjzvskhthsbyn2vmq" # Canonical-Ubuntu-22.04-aarch64-2022.06.16-0
 }
 
 variable "compute_shape" {
@@ -159,6 +158,11 @@ variable "install_nginx_ingress" {
   default = true
 }
 
+variable "nginx_ingress_release" {
+  type    = string
+  default = "v1.3.1"
+}
+
 variable "install_certmanager" {
   type    = bool
   default = true
@@ -166,7 +170,7 @@ variable "install_certmanager" {
 
 variable "certmanager_release" {
   type    = string
-  default = "v1.8.2"
+  default = "v1.9.1"
 }
 
 variable "certmanager_email_address" {
@@ -181,7 +185,7 @@ variable "install_longhorn" {
 
 variable "longhorn_release" {
   type    = string
-  default = "v1.2.3"
+  default = "v1.3.1"
 }
 
 variable "expose_kubeapi" {

--- a/vars.tf
+++ b/vars.tf
@@ -27,7 +27,7 @@ variable "cluster_name" {
 }
 
 variable "os_image_id" {
-  type    = string
+  type = string
 }
 
 variable "fault_domains" {


### PR DESCRIPTION
Updated nginx ingress, longhorn, cert-manager versions. Added nginx ingress controller version as variable. os_image_id now is a required variable, since the image ocid change form region to region. Updated README.md