### PR TITLE
Update vars.tf for longhorn compatibility.

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -28,7 +28,7 @@ variable "os_image_id" {
 
 variable "k3s_version" {
   type    = string
-  default = "latest"
+  default = "v1.24.6+k3s1"
 }
 
 variable "k3s_subnet" {


### PR DESCRIPTION
Longhorn 1.3.2 is not compatible with k3s 1.25, which gets installed using the 'latest' tag.

Errors occur with the longhorn install when k3s 1.25 is used.

I wasn't able to find a tag to only install updated versions of 1.24 only, which would have been preferred to pinning it to one version.