### PR TITLE
Added variable k3s_extra_worker_node. Using OCI always free account y…

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,9 @@ Once you have created the terraform.tfvars file edit the main.tf file (always in
 | `public_lb_shape`  | `no`  | LB shape for the public LB. Default: flexible. **NOTE** is mandatory to use this kind of shape to provision two always free LB (public and private)  |
 | `http_lb_port`  | `no`  | http port used by the public LB. Default: 80  |
 | `https_lb_port`  | `no`  | http port used by the public LB. Default: 443  |
-| `k3s_server_pool_size`  | `no`  | Number of k3s servers deployed. Default 2  |
+| `k3s_server_pool_size`  | `no`  | Number of k3s servers deployed. Default 1  |
 | `k3s_worker_pool_size`  | `no`  | Number of k3s workers deployed. Default 2  |
+| `k3s_extra_worker_node`  | `no`  | Boolean value, default true. Deploy the third worker nodes. The node will be deployed outside the worker instance pools. Using OCI always free account you can't create instance pools with more than two servers. This workaround solve this problem. |
 | `install_nginx_ingress`  | `no`  | Boolean value, install kubernetes nginx ingress controller instead of Traefik. Default: true. For more information see [Nginx ingress controller](#nginx-ingress-controller) |
 | `install_traefik2`  | `no`  | Boolean value, install [Traefik 2](https://traefik.io/) ingress controller instead of the [embedded k3s Traefik](https://docs.k3s.io/networking#traefik-ingress-controller). Default: false. |
 | `disable_ingress`  | `no`  | Boolean value, disable all ingress controllers. Default: false |

--- a/k3s-workers.tf
+++ b/k3s-workers.tf
@@ -29,3 +29,67 @@ resource "oci_core_instance_pool" "k3s_workers" {
     "k3s-instance-type"     = "k3s-worker"
   }
 }
+
+resource "oci_core_instance" "k3s_extra_worker_node" {
+  count = var.k3s_extra_worker_node ? 1 : 0
+  depends_on = [
+    oci_load_balancer_load_balancer.k3s_load_balancer,
+    oci_core_instance_pool.k3s_workers
+  ]
+
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  display_name        = "K3s extra worker node"
+
+  agent_config {
+    is_management_disabled = "false"
+    is_monitoring_disabled = "false"
+
+    plugins_config {
+      desired_state = "DISABLED"
+      name          = "Vulnerability Scanning"
+    }
+
+    plugins_config {
+      desired_state = "ENABLED"
+      name          = "Compute Instance Monitoring"
+    }
+
+    plugins_config {
+      desired_state = "DISABLED"
+      name          = "Bastion"
+    }
+  }
+
+  shape = var.compute_shape
+  shape_config {
+    memory_in_gbs = "6"
+    ocpus         = "1"
+  }
+
+  source_details {
+    source_id   = var.os_image_id
+    source_type = "image"
+  }
+
+  create_vnic_details {
+    assign_private_dns_record = true
+    assign_public_ip          = true
+    subnet_id                 = oci_core_subnet.default_oci_core_subnet10.id
+    nsg_ids                   = [oci_core_network_security_group.lb_to_instances_http.id]
+    hostname_label            = "k3s-extra-worker-node"
+  }
+
+  metadata = {
+    "ssh_authorized_keys" = file(var.PATH_TO_PUBLIC_KEY)
+    "user_data"           = data.cloudinit_config.k3s_worker_tpl.rendered
+  }
+
+  freeform_tags = {
+    "provisioner"           = "terraform"
+    "environment"           = "${var.environment}"
+    "${var.unique_tag_key}" = "${var.unique_tag_value}"
+    "k3s-cluster-name"      = "${var.cluster_name}"
+    "k3s-instance-type"     = "k3s-worker"
+  }
+}

--- a/k3slb.tf
+++ b/k3slb.tf
@@ -48,6 +48,16 @@ resource "oci_network_load_balancer_backend" "k3s_http_backend" {
   target_id                = data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].id
 }
 
+resource "oci_network_load_balancer_backend" "k3s_http_backend_extra_node" {
+  count = var.k3s_extra_worker_node ? 1 : 0
+
+  backend_set_name         = oci_network_load_balancer_backend_set.k3s_http_backend_set.name
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
+  name                     = format("%s:%s", oci_core_instance.k3s_extra_worker_node[count.index].id, var.http_lb_port)
+  port                     = var.http_lb_port
+  target_id                = oci_core_instance.k3s_extra_worker_node[count.index].id
+}
+
 # HTTPS
 resource "oci_network_load_balancer_listener" "k3s_https_listener" {
   default_backend_set_name = oci_network_load_balancer_backend_set.k3s_https_backend_set.name
@@ -80,6 +90,16 @@ resource "oci_network_load_balancer_backend" "k3s_https_backend" {
   name                     = format("%s:%s", data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].id, var.https_lb_port)
   port                     = var.https_lb_port
   target_id                = data.oci_core_instance_pool_instances.k3s_workers_instances.instances[count.index].id
+}
+
+resource "oci_network_load_balancer_backend" "k3s_https_backend_extra_node" {
+  count = var.k3s_extra_worker_node ? 1 : 0
+
+  backend_set_name         = oci_network_load_balancer_backend_set.k3s_https_backend_set.name
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.k3s_public_lb.id
+  name                     = format("%s:%s", oci_core_instance.k3s_extra_worker_node[count.index].id, var.https_lb_port)
+  port                     = var.https_lb_port
+  target_id                = oci_core_instance.k3s_extra_worker_node[count.index].id
 }
 
 ## kube-api

--- a/vars.tf
+++ b/vars.tf
@@ -136,12 +136,17 @@ variable "ingress_controller_https_nodeport" {
 
 variable "k3s_server_pool_size" {
   type    = number
-  default = 2
+  default = 1
 }
 
 variable "k3s_worker_pool_size" {
   type    = number
   default = 2
+}
+
+variable "k3s_extra_worker_node" {
+  type    = bool
+  default = true
 }
 
 variable "unique_tag_key" {


### PR DESCRIPTION
Added variable k3s_extra_worker_node. Using OCI always free account you can't create instance pools with more than two servers. This workaround solve this problem. Decreased number of master from 2 to 1