### PR TITLE
Updates docs and `example/` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ terraform.rc
 main.tf_ori
 
 ssl/
+
+*.ignore*

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This module was tested with:
 ### Terraform OCI user creation (Optional)
 
 Is always recommended to create a separate user and group in your preferred [domain](https://cloud.oracle.com/identity/domains) to use with Terraform.
-This user must have less privileges possible (Zero trust policy). Below is an example policy that you can [create](https://cloud.oracle.com/identity/policies) allow *terraform-group* to manage all the resources needed by this module:
+This user must have less privileges possible (Zero trust policy). Below is an example policy that you can [create](https://cloud.oracle.com/identity/policies) allow `terraform-group` to manage all the resources needed by this module:
 
 ```
 Allow group terraform-group to manage virtual-network-family  in compartment id <compartment_ocid>
@@ -84,63 +84,67 @@ chmod 600 ~/.oci/<your_name>-oracle-cloud.pem
 openssl rsa -pubout -in ~/.oci/<your_name>-oracle-cloud.pem -out ~/.oci/<your_name>-oracle-cloud_public.pem
 ```
 
-replace *<your_name>* with your name or a string you prefer.
+replace `<your_name>` with your name or a string you prefer.
 
-**NOTE** ~/.oci/<your_name>-oracle-cloud_public.pem this string will be used on the *terraform.tfvars* used by the Oracle provider plugin, so please take note of this string.
+**NOTE**: `~/.oci/<your_name>-oracle-cloud_public.pem` will be used in  `terraform.tfvars` by the Oracle provider plugin, so please take note of this string.
 
 ### Project setup
 
-Clone this repo and go in the *example/* directory:
+Clone this repo and go in the `example/` directory:
 
 ```
 git clone https://github.com/garutilorenzo/k3s-oci-cluster.git
 cd k3s-oci-cluster/example/
 ```
 
-Now you have to edit the *main.tf* file and you have to create the *terraform.tfvars* file. For more detail see [Oracle provider setup](#oracle-provider-setup) and [Pre flight checklist](#pre-flight-checklist).
+Now you have to edit the `main.tf` file and you have to create the `terraform.tfvars` file. For more detail see [Oracle provider setup](#oracle-provider-setup) and [Pre flight checklist](#pre-flight-checklist).
 
 Or if you prefer you can create an new empty directory in your workspace and create this three files:
 
-* terraform.tfvars - More details in [Oracle provider setup](#oracle-provider-setup)
-* main.tf
-* provider.tf
+* `terraform.tfvars` - More details in [Oracle provider setup](#oracle-provider-setup)
+* `main.tf`
+* `provider.tf`
 
-The main.tf file will look like:
+The `main.tf` file will look like:
 
 
 ```
-variable "compartment_ocid" {
-
+variable "compartment_ocid" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "public_key_path" {}
+variable "availability_domain" {}
+variable "my_public_ip_cidr" {}
+variable "cluster_name" {}
+variable "os_image_id" {}
+variable "certmanager_email_address" {}
+variable "k3s_server_pool_size" {
+  default = 1
 }
-
-variable "tenancy_ocid" {
-
+variable "k3s_worker_pool_size" {
+  default = 2
 }
-
-variable "user_ocid" {
-
-}
-
-variable "fingerprint" {
-
-}
-
-variable "private_key_path" {
-
-}
-
-variable "region" {
-  default = "<change_me>"
-}
+variable "region" {}
 
 module "k3s_cluster" {
-  region              = var.region
-  availability_domain = "<change_me>"
-  compartment_ocid    = var.compartment_ocid
-  my_public_ip_cidr   = "<change_me>"
-  cluster_name        = "<change_me>"
-  environment         = "staging"
-  source              = "github.com/garutilorenzo/k3s-oci-cluster"
+  # k3s_version               = "v1.23.8+k3s2" # Fix kubectl exec failure
+  # k3s_version               = "v1.24.4+k3s1" # Kubernetes version compatible with longhorn
+  region                    = var.region
+  availability_domain       = var.availability_domain
+  tenancy_ocid              = var.tenancy_ocid
+  compartment_ocid          = var.compartment_ocid
+  my_public_ip_cidr         = var.my_public_ip_cidr
+  cluster_name              = var.cluster_name
+  public_key_path           = var.public_key_path
+  environment               = "staging"
+  os_image_id               = var.os_image_id
+  certmanager_email_address = var.certmanager_email_address
+  k3s_server_pool_size      = var.k3s_server_pool_size
+  k3s_worker_pool_size      = var.k3s_worker_pool_size
+  ingress_controller        = "nginx"
+  source                    = "../"
 }
 
 output "k3s_servers_ips" {
@@ -158,7 +162,7 @@ output "public_lb_ip" {
 
 For all the possible variables see [Pre flight checklist](#pre-flight-checklist)
 
-The provider.tf will look like:
+The `provider.tf` will look like:
 
 ```
 provider "oci" {
@@ -201,7 +205,7 @@ commands will detect it and remind you to do so if necessary.
 
 ### Oracle provider setup
 
-In the *example/* directory of this repo you need to create a terraform.tfvars file, the file will look like:
+In the `example/` directory of this repo you need to create a `terraform.tfvars` file, the file will look like:
 
 ```
 fingerprint      = "<rsa_key_fingerprint>"
@@ -211,17 +215,17 @@ tenancy_ocid     = "<tenency_ocid>"
 compartment_ocid = "<compartment_ocid>"
 ```
 
-To find your tenency_ocid in the Ocacle Cloud console go to: Governance and Administration > Tenency details, then copy the OCID.
+To find your `tenency_ocid` in the Ocacle Cloud console go to: **Governance and Administration > Tenency details**, then copy the OCID.
 
-To find you user_ocid in the Ocacle Cloud console go to User setting (click on the icon in the top right corner, then click on User settings), click your username and then copy the OCID
+To find you `user_ocid` in the Ocacle Cloud console go to **User setting** (click on the icon in the top right corner, then click on User settings), click your username and then copy the OCID.
 
-The compartment_ocid is the same as tenency_ocid.
+The `compartment_ocid` is the same as `tenency_ocid`.
 
-The fingerprint is the fingerprint of your RSA key, you can find this vale under User setting > API Keys
+The fingerprint is the fingerprint of your RSA key, you can find this vale under **User setting > API Keys**.
 
 ### Pre flight checklist
 
-Once you have created the terraform.tfvars file edit the main.tf file (always in the *example/* directory) and set the following variables:
+Once you have created the terraform.tfvars file edit the `main.tf` file (always in the `example/` directory) and set the following variables:
 
 | Var   | Required | Desc |
 | ------- | ------- | ----------- |
@@ -230,6 +234,8 @@ Once you have created the terraform.tfvars file edit the main.tf file (always in
 | `compartment_ocid` | `yes`        | Set the correct compartment ocid. See [how](#oracle-provider-setup) to find the compartment ocid |
 | `cluster_name` | `yes`        | the name of your K3s cluster. Default: k3s-cluster |
 | `my_public_ip_cidr` | `yes`        |  your public ip in cidr format (Example: 195.102.xxx.xxx/32) |
+| `private_key_path`     | `yes`       | Path to your private ssh key |
+| `public_key_path`     | `yes`       | Path to your public ssh key |
 | `environment`  | `yes`  | Current work environment (Example: staging/dev/prod). This value is used for tag all the deployed resources |
 | `os_image_id`  | `yes`  | Image id to use. See [how](#how-to-list-all-the-os-images) to list all available OS images |
 | `k3s_version`  | `no`  | K3s version. Default: latest |
@@ -269,7 +275,6 @@ Once you have created the terraform.tfvars file edit the main.tf file (always in
 | `unique_tag_key`  | `no`  | Unique tag name used for tagging all the deployed resources. Default: k3s-provisioner |
 | `unique_tag_value`  | `no`  | Unique value used with  unique_tag_key. Default: https://github.com/garutilorenzo/k3s-oci-cluster |
 | `expose_kubeapi`  | `no`  | Boolean value, default false. Expose or not the kubeapi server to the internet. Access is granted only from *my_public_ip_cidr* for security reasons. |
-| `PATH_TO_PUBLIC_KEY`     | `no`       | Path to your public ssh key (Default: "~/.ssh/id_rsa.pub) |
 
 
 #### How to find the availability doamin name
@@ -327,15 +332,15 @@ oci compute image list --compartment-id <compartment_ocid> --operating-system "C
 
 ## Notes about OCI always free resources
 
-In order to get the maximum resources available within the oracle always free tier, the max amount of the k3s servers and k3s workers must be 2. So the max value for *k3s_server_pool_size* and *k3s_worker_pool_size* **is** 2.
+In order to get the maximum resources available within the oracle always free tier, the max amount of the k3s servers and k3s workers must be 2. So the **max value** for `k3s_server_pool_size` and `k3s_worker_pool_size` is `2`.
 
-In this setup we use two LB, one internal LB and one public LB (Layer 7). In order to use two LB using the always free resources, one lb must be a [network load balancer](https://docs.oracle.com/en-us/iaas/Content/NetworkLoadBalancer/introducton.htm#Overview) an the other must be a [load balancer](https://docs.oracle.com/en-us/iaas/Content/Balance/Concepts/balanceoverview.htm). The public LB **must** use the *flexible* shape (*public_lb_shape* variable).
+In this setup we use two LB, one internal LB and one public LB (Layer 7). In order to use two LB using the always free resources, one lb must be a [network load balancer](https://docs.oracle.com/en-us/iaas/Content/NetworkLoadBalancer/introducton.htm#Overview) an the other must be a [load balancer](https://docs.oracle.com/en-us/iaas/Content/Balance/Concepts/balanceoverview.htm). The public LB **must** use the `flexible` shape (`public_lb_shape` variable).
 
 ## Notes about K3s
 
 In this environment the High Availability of the K3s cluster is provided using the Embedded DB. More details [here](https://rancher.com/docs/k3s/latest/en/installation/ha-embedded/)
 
-The default installation of K3s install [Traefik](https://docs.k3s.io/networking#traefik-ingress-controller) as ingress the controller. In this environment Traefik is replaced by [Nginx ingress controller](https://kubernetes.github.io/ingress-nginx/). To install Traefik as the ingress controller set the variable *ingress_controller* to *default*.
+The default installation of K3s install [Traefik](https://docs.k3s.io/networking#traefik-ingress-controller) as ingress the controller. In this environment Traefik is replaced by [Nginx ingress controller](https://kubernetes.github.io/ingress-nginx/). To install Traefik as the ingress controller set the variable `ingress_controller` to `default`.
 For more details on Nginx ingress controller see the [Nginx ingress controller](#nginxingress-controller) section.
 
 ## Infrastructure overview
@@ -343,8 +348,8 @@ For more details on Nginx ingress controller see the [Nginx ingress controller](
 The final infrastructure will be made by:
 
 * two instance pool:
-  * one instance pool for the server nodes named "k3s-servers"
-  * one instance pool for the worker nodes named "k3s-workers"
+  * one instance pool for the server nodes named `k3s-servers`
+  * one instance pool for the worker nodes named `k3s-workers`
 * one internal load balancer that will route traffic to K3s servers
 * one external load balancer that will route traffic to K3s workers
 
@@ -361,9 +366,9 @@ The other resources created by terraform are:
 
 ## Cluster resource deployed
 
-This setup will automatically install [longhorn](https://longhorn.io/). Longhorn is a *Cloud native distributed block storage for Kubernetes*. To disable the longhorn deployment set *install_longhorn* variable to *false*
+This setup will automatically install [longhorn](https://longhorn.io/). Longhorn is a *Cloud native distributed block storage for Kubernetes*. To disable the longhorn deployment set `install_longhorn` variable to `false`.
 
-**NOTE** to use longhorn set the *k3s_version* < v1.25.x [Ref.](https://github.com/longhorn/longhorn/issues/4003)
+**NOTE** to use longhorn set the `k3s_version` < `v1.25.x` [Ref.](https://github.com/longhorn/longhorn/issues/4003)
 
 ### Nginx ingress controller
 
@@ -425,8 +430,8 @@ metadata:
 **NOTE** to use nginx ingress controller with the proxy protocol enabled, an external nginx instance is used as proxy (since OCI LB doesn't support proxy protocol at the moment). Nginx will be installed on each worker node and the configuation of nginx will:
 
 * listen in proxy protocol mode
-* forward the traffic from port 80 to ingress_controller_http_nodeport (default to 30080) on any server of the cluster
-* forward the traffic from port 443 to ingress_controller_https_nodeport (default to 30443) on any server of the cluster
+* forward the traffic from port `80` to `ingress_controller_http_nodeport` (default to `30080`) on any server of the cluster
+* forward the traffic from port `443` to `ingress_controller_https_nodeport` (default to `30443`) on any server of the cluster
 
 This is the final result:
 
@@ -591,7 +596,7 @@ curl -v http://<PUBLIC_LB_IP>
 * Connection #0 to host PUBLIC_LB_IP left intact
 ```
 
-*404* is a correct response since the cluster is empty. We can test also the https listener/backends:
+`404` is a correct response since the cluster is empty. We can test also the https listener/backends:
 
 ```
 curl -k -v https://<PUBLIC_LB_IP>
@@ -744,14 +749,14 @@ kubectl apply -f https://raw.githubusercontent.com/garutilorenzo/k3s-oci-cluster
 kubectl apply -f https://raw.githubusercontent.com/garutilorenzo/k3s-oci-cluster/master/deployments/wordpress/all-resources.yml
 ```
 
-**NOTE** The Wordpress installation is **secured**. To allow external traffic to /wp-admin, /xmlrpc.php and wp-login.php you have to edit the  [deployments/nginx/all-resources.yml](https://github.com/garutilorenzo/k3s-oci-cluster/blob/master/deployments/nginx/all-resources.yml) and change this line:
+**NOTE** The Wordpress installation is **secured**. To allow external traffic to `/wp-admin`, `/xmlrpc.php` and `wp-login.php` you have to edit the  [deployments/nginx/all-resources.yml](https://github.com/garutilorenzo/k3s-oci-cluster/blob/master/deployments/nginx/all-resources.yml) and change this line:
 
 ```yaml
 - name: SECURE_SUBNET
   value: 8.8.8.8/32 # change-me
 ```
 
-whit your public ip address CIDR.
+with your public ip address CIDR.
 
 ```
 curl -o nginx-all-resources.yml https://raw.githubusercontent.com/garutilorenzo/k3s-oci-cluster/master/deployments/nginx/all-resources.yml
@@ -811,7 +816,7 @@ Error: 409-Conflict, Invalid State Transition of NLB lifeCycle state from Updati
 │ API Reference: https://docs.oracle.com/iaas/api/#/en/networkloadbalancer/20200501/Listener/DeleteListener 
 ```
 
-re-run *terraform destroy*
+re-run `terraform destroy`
 
 ### kubectl exec failure
 

--- a/README.md
+++ b/README.md
@@ -14,21 +14,33 @@ Deploy a Kubernetes cluster for free, using K3s and Oracle [always free](https:/
 
 # Table of Contents
 
-* [Important notes](#important-notes)
-* [Requirements](#requirements)
-* [Supported OS](#supported-os)
-* [Example RSA key generation](#example-rsa-key-generation)
-* [Project setup](#project-setup)
-* [Oracle provider setup](#oracle-provider-setup)
-* [Pre flight checklist](#pre-flight-checklist)
-* [Notes about OCI always free resources](#notes-about-oci-always-free-resources)
-* [Notes about K3s](#notes-about-k3s)
-* [Infrastructure overview](#infrastructure-overview)
-* [Cluster resource deployed](#cluster-resource-deployed)
-* [Deploy](#deploy)
-* [Deploy a sample stack](#deploy-a-sample-stack)
-* [Clean up](#clean-up)
-* [Known Bugs](#known-bugs)
+- [OCI K3s cluster](#oci-k3s-cluster)
+- [Table of Contents](#table-of-contents)
+    - [Important notes](#important-notes)
+    - [Requirements](#requirements)
+    - [Supported OS](#supported-os)
+    - [Terraform OCI user creation (Optional)](#terraform-oci-user-creation-optional)
+      - [Example RSA key generation](#example-rsa-key-generation)
+    - [Project setup](#project-setup)
+    - [Oracle provider setup](#oracle-provider-setup)
+    - [Pre flight checklist](#pre-flight-checklist)
+      - [How to find the availability doamin name](#how-to-find-the-availability-doamin-name)
+      - [How to list all the OS images](#how-to-list-all-the-os-images)
+  - [Notes about OCI always free resources](#notes-about-oci-always-free-resources)
+  - [Notes about K3s](#notes-about-k3s)
+  - [Infrastructure overview](#infrastructure-overview)
+  - [Cluster resource deployed](#cluster-resource-deployed)
+    - [Nginx ingress controller](#nginx-ingress-controller)
+    - [Cert-manager](#cert-manager)
+  - [Deploy](#deploy)
+      - [Public LB check](#public-lb-check)
+      - [Longhorn check](#longhorn-check)
+      - [Argocd check](#argocd-check)
+  - [Deploy a sample stack](#deploy-a-sample-stack)
+  - [Clean up](#clean-up)
+  - [Known Bugs](#known-bugs)
+    - [409-Conflict](#409-conflict)
+    - [kubectl exec failure](#kubectl-exec-failure)
 
 **Note** choose a region with enough ARM capacity
 
@@ -69,6 +81,7 @@ Allow group terraform-group to manage network-load-balancers  in compartment id 
 Allow group terraform-group to manage dynamic-groups in compartment id <compartment_ocid>
 Allow group terraform-group to manage policies in compartment id <compartment_ocid>
 Allow group terraform-group to read network-load-balancers  in compartment id <compartment_ocid>
+Allow group terraform-group to manage dynamic-groups in tenancy
 ```
 
 See [how](#oracle-provider-setup) to find the compartment ocid. The user and the group have to be manually created before using this module.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This module was tested with:
 
 ### Terraform OCI user creation (Optional)
 
-Is always recommended to create a separate user an group to use with Terraform. This user must have less privileges possible (Zero trust policy). This is an example policy that allow *terraform-group* to manage all the resources needed by this module:
+Is always recommended to create a separate user and group in your preferred [domain](https://cloud.oracle.com/identity/domains) to use with Terraform.
+This user must have less privileges possible (Zero trust policy). Below is an example policy that you can [create](https://cloud.oracle.com/identity/policies) allow *terraform-group* to manage all the resources needed by this module:
 
 ```
 Allow group terraform-group to manage virtual-network-family  in compartment id <compartment_ocid>
@@ -71,7 +72,7 @@ Allow group terraform-group to read network-load-balancers  in compartment id <c
 ```
 
 See [how](#oracle-provider-setup) to find the compartment ocid. The user and the group have to be manually created before using this module.
-To create the user go to Identity & Security -> Users, then create the group in Identity & Security -> Groups and associate the newly created user to the group. The last step is to create the policy in Identity & Security -> Policies.
+To create the user go to **Identity & Security -> Users**, then create the group in **Identity & Security -> Groups** and associate the newly created user to the group. The last step is to create the policy in **Identity & Security -> Policies**.
 
 #### Example RSA key generation
 

--- a/example/.terraform.lock.hcl
+++ b/example/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/cloudinit" {
   version = "2.2.0"
   hashes = [
+    "h1:Id6dDkpuSSLbGPTdbw49bVS/7XXHu/+d7CJoGDqtk5g=",
     "h1:tQLNREqesrdCQ/bIJnl0+yUK+XfdWzAG0wo4lp10LvM=",
     "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
     "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
@@ -22,6 +23,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.4.3"
   hashes = [
+    "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
     "h1:xZGZf18JjMS06pFa4NErzANI98qi59SEcBsOcS2P2yQ=",
     "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
     "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
@@ -42,6 +44,7 @@ provider "registry.terraform.io/oracle/oci" {
   version     = "4.103.0"
   constraints = ">= 4.64.0"
   hashes = [
+    "h1:BhoJ0feyc/NOYfTASKokU9prndVtSFpKVoe3ve7hs18=",
     "h1:S2W+Ws/6rUPbWHJfY4opXJXCP7qkiIrhK7tUSxvRqgg=",
     "zh:4353fcba6ecc24a9002620fb9be90f69aea8944be3e066661babd53e12e73070",
     "zh:552aba3d96e2a243ddff23b28ad473e6299ca15e63b4de1fa0cde17733477663",

--- a/example/main.tf
+++ b/example/main.tf
@@ -3,6 +3,7 @@ variable "tenancy_ocid" {}
 variable "user_ocid" {}
 variable "fingerprint" {}
 variable "private_key_path" {}
+variable "public_key_path" {}
 variable "availability_domain" {}
 variable "my_public_ip_cidr" {}
 variable "cluster_name" {}
@@ -25,6 +26,7 @@ module "k3s_cluster" {
   compartment_ocid          = var.compartment_ocid
   my_public_ip_cidr         = var.my_public_ip_cidr
   cluster_name              = var.cluster_name
+  public_key_path           = var.public_key_path
   environment               = "staging"
   os_image_id               = var.os_image_id
   certmanager_email_address = var.certmanager_email_address

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,39 +1,35 @@
-variable "compartment_ocid" {
-
+variable "compartment_ocid" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "availability_domain" {}
+variable "my_public_ip_cidr" {}
+variable "cluster_name" {}
+variable "os_image_id" {}
+variable "certmanager_email_address" {}
+variable "k3s_server_pool_size" {
+  default = 1
 }
-
-variable "tenancy_ocid" {
-
+variable "k3s_worker_pool_size" {
+  default = 2
 }
-
-variable "user_ocid" {
-
-}
-
-variable "fingerprint" {
-
-}
-
-variable "private_key_path" {
-
-}
-
-variable "region" {
-  default = "<change_me>"
-}
+variable "region" {}
 
 module "k3s_cluster" {
   # k3s_version               = "v1.23.8+k3s2" # Fix kubectl exec failure
   # k3s_version               = "v1.24.4+k3s1" # Kubernetes version compatible with longhorn
   region                    = var.region
-  availability_domain       = "<change_me>"
+  availability_domain       = var.availability_domain
   tenancy_ocid              = var.tenancy_ocid
   compartment_ocid          = var.compartment_ocid
-  my_public_ip_cidr         = "<change_me>"
-  cluster_name              = "<change_me>"
+  my_public_ip_cidr         = var.my_public_ip_cidr
+  cluster_name              = var.cluster_name
   environment               = "staging"
-  os_image_id               = "<change_me>"
-  certmanager_email_address = "<change_me>"
+  os_image_id               = var.os_image_id
+  certmanager_email_address = var.certmanager_email_address
+  k3s_server_pool_size      = var.k3s_server_pool_size
+  k3s_worker_pool_size      = var.k3s_worker_pool_size
   ingress_controller        = "nginx"
   source                    = "../"
 }

--- a/k3s-workers.tf
+++ b/k3s-workers.tf
@@ -81,7 +81,7 @@ resource "oci_core_instance" "k3s_extra_worker_node" {
   }
 
   metadata = {
-    "ssh_authorized_keys" = file(var.PATH_TO_PUBLIC_KEY)
+    "ssh_authorized_keys" = file(var.public_key_path)
     "user_data"           = data.cloudinit_config.k3s_worker_tpl.rendered
   }
 

--- a/template.tf
+++ b/template.tf
@@ -47,7 +47,7 @@ resource "oci_core_instance_configuration" "k3s_server_template" {
       display_name = "k3s server template"
 
       metadata = {
-        "ssh_authorized_keys" = file(var.PATH_TO_PUBLIC_KEY)
+        "ssh_authorized_keys" = file(var.public_key_path)
         "user_data"           = data.cloudinit_config.k3s_server_tpl.rendered
       }
 
@@ -113,7 +113,7 @@ resource "oci_core_instance_configuration" "k3s_worker_template" {
       display_name = "k3s worker template"
 
       metadata = {
-        "ssh_authorized_keys" = file(var.PATH_TO_PUBLIC_KEY)
+        "ssh_authorized_keys" = file(var.public_key_path)
         "user_data"           = data.cloudinit_config.k3s_worker_tpl.rendered
       }
 

--- a/vars.tf
+++ b/vars.tf
@@ -41,7 +41,7 @@ variable "fault_domains" {
   default = ["FAULT-DOMAIN-1", "FAULT-DOMAIN-2", "FAULT-DOMAIN-3"]
 }
 
-variable "PATH_TO_PUBLIC_KEY" {
+variable "public_key_path" {
   type        = string
   default     = "~/.ssh/id_rsa.pub"
   description = "Path to your public key"


### PR DESCRIPTION
- Prettify docs and added required `Allow group terraform-group to manage dynamic-groups in tenancy` policy statement for zero trust install.
- Updated `example/` folder with required variables.