### PR TITLE
Chore: bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,16 +279,16 @@ Once you have created the terraform.tfvars file edit the `main.tf` file (always 
 | `disable_ingress`  | `no`  | Boolean value, disable all ingress controllers. Default: false |
 | `ingress_controller_http_nodeport`  | `no`  | NodePort where nginx ingress will listen for http traffic. Default 30080  |
 | `ingress_controller_https_nodeport`  | `no`  | NodePort where nginx ingress will listen for https traffic.  Default 30443 |
-| `install_longhorn`  | `no`  | Boolean value, install longhorn "Cloud native distributed block storage for Kubernetes". Default: true. To use longhorn set the *k3s_version* < v1.25.x [Ref.](https://github.com/longhorn/longhorn/issues/4003)  |
-| `longhorn_release`  | `no`  | Longhorn release. Default: v1.4.0  |
+| `install_longhorn`  | `no`  | Boolean value, install longhorn "Cloud native distributed block storage for Kubernetes". Default: true. |
+| `longhorn_release`  | `no`  | Longhorn release. Default: v1.8.1  |
 | `install_certmanager`  | `no`  | Boolean value, install [cert manager](https://cert-manager.io/) "Cloud native certificate management". Default: true  |
-| `nginx_ingress_release`  | `no`  | Longhorn release. Default: v1.5.1  |
-| `certmanager_release`  | `no`  | Cert manager release. Default: v1.11.0  |
-| `certmanager_email_address`  | `no`  | Email address used for signing https certificates. Defaul: changeme@example.com  |
+| `nginx_ingress_release`  | `no`  | Longhorn release. Default: v1.12.1  |
+| `certmanager_release`  | `no`  | Cert manager release. Default: v1.12.16  |
+| `certmanager_email_address`  | `no`  | Email address used for signing https certificates. Default: changeme@example.com  |
 | `install_argocd`  | `no`  | Boolean value, install [Argo CD](https://argo-cd.readthedocs.io/en/stable/) "a declarative, GitOps continuous delivery tool for Kubernetes.". Default: true  |
-| `argocd_release`  | `no`  | Argo CD release. Default: v2.4.11  |
+| `argocd_release`  | `no`  | Argo CD release. Default: v2.14.9  |
 | `install_argocd_image_updater`  | `no`  | Boolean value, install [Argo CD Image Updater](https://argocd-image-updater.readthedocs.io/en/stable/) "A tool to automatically update the container images of Kubernetes workloads that are managed by Argo CD.". Default: true  |
-| `argocd_image_updater_release`  | `no`  | Argo CD release Image Updater. Default: v0.12.0  |
+| `argocd_image_updater_release`  | `no`  | Argo CD release Image Updater. Default: v0.16.0 |
 | `unique_tag_key`  | `no`  | Unique tag name used for tagging all the deployed resources. Default: k3s-provisioner |
 | `unique_tag_value`  | `no`  | Unique value used with  unique_tag_key. Default: https://github.com/garutilorenzo/k3s-oci-cluster |
 | `expose_kubeapi`  | `no`  | Boolean value, default false. Expose or not the kubeapi server to the internet. Access is granted only from *my_public_ip_cidr* for security reasons. |
@@ -384,8 +384,6 @@ The other resources created by terraform are:
 ## Cluster resource deployed
 
 This setup will automatically install [longhorn](https://longhorn.io/). Longhorn is a *Cloud native distributed block storage for Kubernetes*. To disable the longhorn deployment set `install_longhorn` variable to `false`.
-
-**NOTE** to use longhorn set the `k3s_version` < `v1.25.x` [Ref.](https://github.com/longhorn/longhorn/issues/4003)
 
 ### Nginx ingress controller
 

--- a/nginx-ingress-config/all-resources.yml
+++ b/nginx-ingress-config/all-resources.yml
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.16
+    app.kubernetes.io/version: 1.12.1
+    helm.sh/chart: ingress-nginx-4.12.1
   name: ingress-nginx-controller
   namespace: ingress-nginx

--- a/vars.tf
+++ b/vars.tf
@@ -185,7 +185,7 @@ variable "ingress_controller" {
 
 variable "nginx_ingress_release" {
   type    = string
-  default = "v1.5.1"
+  default = "v1.12.1"
 }
 
 variable "install_certmanager" {
@@ -195,7 +195,7 @@ variable "install_certmanager" {
 
 variable "certmanager_release" {
   type    = string
-  default = "v1.11.0"
+  default = "v1.12.16"
 }
 
 variable "certmanager_email_address" {
@@ -210,7 +210,7 @@ variable "install_longhorn" {
 
 variable "longhorn_release" {
   type    = string
-  default = "v1.4.0"
+  default = "v1.8.1"
 }
 
 variable "install_argocd" {
@@ -220,7 +220,7 @@ variable "install_argocd" {
 
 variable "argocd_release" {
   type    = string
-  default = "v2.4.11"
+  default = "v2.14.9"
 }
 
 variable "install_argocd_image_updater" {
@@ -230,7 +230,7 @@ variable "install_argocd_image_updater" {
 
 variable "argocd_image_updater_release" {
   type    = string
-  default = "v0.12.0"
+  default = "v0.16.0"
 }
 
 variable "expose_kubeapi" {


### PR DESCRIPTION
Bump versions of:
* Longhorn
* nginx-ingress
* ArgoCD
* ArgoCD Image updater

to the latest versions available. Tested on Ubuntu 22.04