### PR TITLE
feat: add Renovate config for automated dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ override.tf.json
 terraform.rc
 
 *.json
+!renovate.json
 
 *Pipfile
 *Pipfile.lock

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "labels": ["dependencies"],
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "regexManagers": [
+    {
+      "description": "cert-manager release",
+      "fileMatch": ["^vars\\.tf$"],
+      "matchStrings": [
+        "variable \"certmanager_release\" \\{[\\s\\S]*?default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "cert-manager/cert-manager",
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Longhorn release",
+      "fileMatch": ["^vars\\.tf$"],
+      "matchStrings": [
+        "variable \"longhorn_release\" \\{[\\s\\S]*?default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "longhorn/longhorn",
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Argo CD release",
+      "fileMatch": ["^vars\\.tf$"],
+      "matchStrings": [
+        "variable \"argocd_release\" \\{[\\s\\S]*?default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "argoproj/argo-cd",
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Argo CD Image Updater release",
+      "fileMatch": ["^vars\\.tf$"],
+      "matchStrings": [
+        "variable \"argocd_image_updater_release\" \\{[\\s\\S]*?default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "argoproj-labs/argocd-image-updater",
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Istio release",
+      "fileMatch": ["^vars\\.tf$"],
+      "matchStrings": [
+        "variable \"istio_release\" \\{[\\s\\S]*?default\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "istio/istio",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group all dependency updates into a single PR",
+      "matchManagers": ["regex"],
+      "groupName": "k3s-oci-cluster dependencies",
+      "groupSlug": "k3s-oci-cluster-deps"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json` with one regex manager per dependency, each targeting the `default = "vX.Y.Z"` in the matching variable block in `vars.tf`
- Covered: cert-manager, Longhorn, Argo CD, Argo CD Image Updater, Istio
- All updates are grouped into a single PR to reduce noise
- Adds `!renovate.json` exception to `.gitignore` (the blanket `*.json` rule from the Terraform template would otherwise hide the file)

## Test plan
- [x] Install the Renovate GitHub App on the repository
- [x] Trigger a Renovate dry-run and confirm it detects the correct current versions in `vars.tf`