### PR TITLE
feat: add unattended-upgrades support for Ubuntu nodes

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -35,6 +35,7 @@ data "cloudinit_config" "k3s_server_tpl" {
       longhorn_release                  = var.longhorn_release,
       ingress_controller_http_nodeport  = var.ingress_controller_http_nodeport,
       ingress_controller_https_nodeport = var.ingress_controller_https_nodeport,
+      install_unattended_upgrades       = var.install_unattended_upgrades,
     })
   }
 }
@@ -57,6 +58,7 @@ data "cloudinit_config" "k3s_worker_tpl" {
       https_lb_port                     = var.https_lb_port,
       ingress_controller_http_nodeport  = var.ingress_controller_http_nodeport,
       ingress_controller_https_nodeport = var.ingress_controller_https_nodeport,
+      install_unattended_upgrades       = var.install_unattended_upgrades,
     })
   }
 }

--- a/files/k3s-install-agent.sh
+++ b/files/k3s-install-agent.sh
@@ -47,6 +47,29 @@ install_oci_cli_oracle(){
   fi
 }
 
+configure_unattended_upgrades() {
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y unattended-upgrades
+
+  cat > /etc/apt/apt.conf.d/20auto-upgrades << 'EOF'
+APT::Periodic::Enable "1";
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";
+EOF
+
+  mkdir -p /etc/systemd/system/apt-daily-upgrade.timer.d
+  cat > /etc/systemd/system/apt-daily-upgrade.timer.d/override.conf << 'EOF'
+[Timer]
+OnCalendar=
+OnCalendar=*-*-* 02:00
+RandomizedDelaySec=0
+Persistent=true
+EOF
+
+  systemctl daemon-reload
+}
+
 wait_lb() {
 while [ true ]
 do
@@ -83,6 +106,10 @@ if [[ "$operating_system" == "ubuntu" ]]; then
   echo "SystemMaxUse=100M" >> /etc/systemd/journald.conf
   echo "SystemMaxFileSize=100M" >> /etc/systemd/journald.conf
   systemctl restart systemd-journald
+
+%{ if install_unattended_upgrades }
+  configure_unattended_upgrades
+%{ endif }
 fi
 
 if [[ "$operating_system" == "oraclelinux" ]]; then

--- a/files/k3s-install-server.sh
+++ b/files/k3s-install-server.sh
@@ -35,6 +35,29 @@ do
 done
 }
 
+configure_unattended_upgrades() {
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y unattended-upgrades
+
+  cat > /etc/apt/apt.conf.d/20auto-upgrades << 'EOF'
+APT::Periodic::Enable "1";
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";
+EOF
+
+  mkdir -p /etc/systemd/system/apt-daily-upgrade.timer.d
+  cat > /etc/systemd/system/apt-daily-upgrade.timer.d/override.conf << 'EOF'
+[Timer]
+OnCalendar=
+OnCalendar=*-*-* 02:00
+RandomizedDelaySec=0
+Persistent=true
+EOF
+
+  systemctl daemon-reload
+}
+
 install_helm() {
   curl -fsSL -o /root/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
   chmod 700 /root/get_helm.sh
@@ -593,6 +616,10 @@ if [[ "$operating_system" == "ubuntu" ]]; then
   echo "SystemMaxUse=100M" >> /etc/systemd/journald.conf
   echo "SystemMaxFileSize=100M" >> /etc/systemd/journald.conf
   systemctl restart systemd-journald
+
+%{ if install_unattended_upgrades }
+  configure_unattended_upgrades
+%{ endif }
 fi
 
 if [[ "$operating_system" == "oraclelinux" ]]; then

--- a/vars.tf
+++ b/vars.tf
@@ -237,3 +237,9 @@ variable "expose_kubeapi" {
   type    = bool
   default = false
 }
+
+variable "install_unattended_upgrades" {
+  type        = bool
+  default     = true
+  description = "Install and configure unattended-upgrades on Ubuntu nodes (daily at 02:00)"
+}


### PR DESCRIPTION
## Summary

- Adds `install_unattended_upgrades` variable (bool, default `true`) to enable automatic OS security patching on Ubuntu k3s nodes
- Configures `unattended-upgrades` via cloud-init with a fixed daily schedule at 02:00 (no randomized jitter)
- Applies to both server and worker node cloud-init scripts

## Behaviour

When `install_unattended_upgrades = true` (default), the following is configured on Ubuntu nodes at provision time:

- `unattended-upgrades` package installed
- `APT::Periodic` options set to enable daily upgrade downloads and application
- `apt-daily-upgrade.timer` overridden to run at a fixed 02:00 (avoids random delays during the maintenance window)

Set `install_unattended_upgrades = false` to opt out (e.g. if you manage OS patching via a separate CM tool like Ansible).

## Test plan

- [x] Provision a cluster with default settings and verify `unattended-upgrades` is active on nodes
- [x] Provision with `install_unattended_upgrades = false` and verify the package is not installed